### PR TITLE
Fix cache by registering it on instrumentation

### DIFF
--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -1,0 +1,7 @@
+import type NodeCache from 'node-cache';
+
+declare global {
+  var placesCache: NodeCache;
+}
+
+export {};

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -11,4 +11,7 @@ module.exports = withPWA({
   reactStrictMode: false,
   swcMinify: false,
   staticPageGenerationTimeout: 120,
+  experimental: {
+    instrumentationHook: true,
+  },
 });

--- a/app/src/instrumentation.ts
+++ b/app/src/instrumentation.ts
@@ -1,0 +1,15 @@
+import type NodeCache from 'node-cache';
+
+export async function register() {
+
+    // hack: NextJS "global" variables are short-lived, so we're creating a global cache here
+    // that will be available throughout the lifetime of the server
+    if (process.env.NEXT_RUNTIME === 'nodejs') {
+        const NodeCache = (await import('node-cache')).default;
+        const config: NodeCache.Options = {
+            stdTTL: process.env.NODE_ENV === 'production' ? 0 : 60 * 60 * 24 * 7, // 1 week
+        };
+
+        global.placesCache = new NodeCache(config);
+    }
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["global.d.ts", "next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
NextJS variables are short lived per API request. Therefore, if multiple users try to access the app, the API Client will be called for each single one of them and the caching would not work.

To fix this issue, the cache is now registered using the instrumentation feature. This way, the cache will be available for the entire server lifetime